### PR TITLE
[SU-9855] Add grouped Dependabot config and document rebuild/deploy procedure

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,42 @@
+# Dependabot configuration.
+#
+# IMPORTANT: merging a Dependabot PR is NOT a deploy. The shipped artifact is the
+# committed `bin/index.js` ncc bundle, which Dependabot does NOT regenerate. After
+# merging any dependency bump you must run `yarn package`, commit the regenerated
+# `bin/index.js`, and move the `v1` tag — otherwise every consumer keeps running the
+# old code. See "Dependency updates (Dependabot)" in README.md.
+#
+# Updates are grouped (production / development × version / security) so we get a
+# handful of consolidated PRs instead of one PR per advisory.
+#
+# Only the `npm` ecosystem is configured: there are no GitHub Actions workflows in
+# this repo, so the `github-actions` ecosystem would have nothing to monitor.
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 10
+    groups:
+      production-dependencies:
+        applies-to: version-updates
+        dependency-type: "production"
+        patterns:
+          - "*"
+      production-security:
+        applies-to: security-updates
+        dependency-type: "production"
+        patterns:
+          - "*"
+      development-dependencies:
+        applies-to: version-updates
+        dependency-type: "development"
+        patterns:
+          - "*"
+      development-security:
+        applies-to: security-updates
+        dependency-type: "development"
+        patterns:
+          - "*"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -37,6 +37,12 @@ yarn package    # tsc + ncc → bin/index.js
 
 See [README.md](README.md) for the publish procedure. Key thing to remember: all consumers pin `@v1`, so moving the `v1` tag rolls everyone in one shot. There is no per-consumer change required.
 
+## Dependency updates (Dependabot)
+
+- Config lives in [`.github/dependabot.yml`](.github/dependabot.yml). Updates are **grouped** (production / development × version / security) to avoid one PR per advisory. Only the `npm` ecosystem is monitored — there are no GitHub Actions workflows in this repo.
+- **Merging a Dependabot PR does NOT ship the fix.** It only updates `package.json` / `yarn.lock`; the running artifact is the committed `bin/index.js` bundle, which Dependabot does not regenerate. A bare merge leaves consumers on the old code.
+- To actually deploy a dependency bump: check out the change, then `yarn install && yarn lint && yarn test && yarn package`, commit the regenerated `bin/index.js` alongside the lockfile, and **move the `v1` tag** (full steps in README's "Dependency updates (Dependabot)" section). Nothing is live until `v1` moves.
+
 ## Consumers
 
 Currently used by 9 repos: keystone, survata-dashboard, survata-jobs, survata-surveywall-api, campaign-creator, email-service, llm-orchestrator, survata-com, upwave-app. All pin `@v1`. Any breaking change must keep `@v1` working or coordinate updates across all of them.

--- a/README.md
+++ b/README.md
@@ -125,3 +125,35 @@ All consumers reference `Survata/gha.slack@v1`. The `v1` tag is a **floating tag
 - There is no Marketplace release flow. The action is not listed there; consumers reference the repo directly.
 - There is no semantic-versioning automation. You decide when to cut `v1.x.y` and whether to move `v1`.
 - Repository icon: each consumer expects an icon at `https://s3.amazonaws.com/media.upwave.com/slack/<repo-name>.png`. When onboarding a new consumer, upload its icon to that S3 path.
+
+## Dependency updates (Dependabot)
+
+Dependabot is configured in [`.github/dependabot.yml`](.github/dependabot.yml). It runs weekly and **groups** updates into a handful of consolidated PRs (production / development × version / security) rather than opening one PR per advisory.
+
+### ⚠️ Merging a Dependabot PR is NOT a deploy
+
+The artifact that actually runs in consumer workflows is the committed `bin/index.js` bundle, **not** `package.json` / `yarn.lock`. A Dependabot PR only updates the manifests and the lockfile — it does **not** regenerate the bundle. If you merge a Dependabot PR and stop there, every consumer keeps running the old, unpatched code that is still baked into `bin/index.js`.
+
+To actually ship a dependency update you must rebuild the bundle and move the `v1` tag:
+
+1. Merge (or check out) the Dependabot branch so `package.json` / `yarn.lock` are updated.
+
+2. Reinstall, verify, and regenerate the bundle:
+
+   ```bash
+   yarn install
+   yarn lint
+   yarn test
+   yarn package
+   ```
+
+3. Commit the regenerated bundle together with the lockfile change:
+
+   ```bash
+   git add package.json yarn.lock bin/index.js
+   git commit -m "Rebuild bundle after dependency update"
+   ```
+
+4. Follow [Publishing a new version](#publishing-a-new-version) from step 4 — optionally validate via the `v1-rc` tag, then **move the `v1` tag** to the new commit. The rollout is not live until `v1` moves.
+
+A quick way to confirm a bump actually reached the bundle: after `yarn package`, grep `bin/index.js` for the new version string or the patched code before moving `v1`.


### PR DESCRIPTION
## Summary

P0 dependency-hygiene groundwork (ahead of the library upgrades, which will follow in a separate PR).

- **`.github/dependabot.yml`** — there was no Dependabot config, which is why the repo accumulated ~50 single-advisory alerts. This adds weekly, **grouped** npm updates split into four groups (production / development × version-updates / security-updates) so we get a few consolidated PRs instead of one per CVE. Only the `npm` ecosystem is configured — there are no GitHub Actions workflows in this repo for the `github-actions` ecosystem to monitor.
- **README.md** — new "Dependency updates (Dependabot)" section.
- **CLAUDE.md** — matching short note for future Claude Code sessions.

## ⚠️ The key thing being documented

The artifact that runs in all 9 consumer repos is the committed `bin/index.js` ncc bundle — **not** `package.json` / `yarn.lock`. Dependabot only updates the manifests/lockfile; it does **not** regenerate the bundle. So **merging a Dependabot PR does not ship the fix** — consumers keep running the old code baked into `bin/index.js` until someone runs `yarn package`, commits the regenerated bundle, and moves the `v1` tag. Both README.md and CLAUDE.md now spell out that procedure.

## Scope / what's NOT here

No dependency versions are changed in this PR. The actual axios / form-data / follow-redirects / @octokit upgrades (and removal of the unused `@actions/github`) are the follow-up, to be done once this is merged.

## Testing

Docs + config only — no source changes, so the bundle is untouched and `yarn test` / `yarn lint` are unaffected. The `dependabot.yml` was validated for YAML well-formedness and correct group/field structure (`version: 2`, npm ecosystem, four valid groups).

🤖 Generated with [Claude Code](https://claude.com/claude-code)