### PR TITLE
[SU-10263] Add failure highlighting to gha.slack (status input)

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,11 +4,30 @@ A GitHub Action that posts Slack messages from CI workflows. Used by Upwave's ba
 
 ## Usage
 
+Success notification (the default — `status` omitted):
+
 ```yaml
 - name: Send Slack message
-  uses: Survata/gha.slack@v1
+  uses: Survata/gha.slack@v2
   with:
     type: build
+    token: ${{ secrets.SLACK_BOT_TOKEN }}
+  env:
+    REPOSITORY: ${{ github.event.repository.name }}
+    BUILD: ${{ env.DEPLOY_VERSION }}
+    PUSHED_BY: ${{ github.event.pusher.name }}
+    MESSAGE: ${{ github.event.head_commit.message }}
+```
+
+Failure notification — an `if: failure()` step with `status: failure`:
+
+```yaml
+- name: Send Slack message (if failed)
+  uses: Survata/gha.slack@v2
+  if: failure()
+  with:
+    type: build
+    status: failure
     token: ${{ secrets.SLACK_BOT_TOKEN }}
   env:
     REPOSITORY: ${{ github.event.repository.name }}
@@ -22,8 +41,18 @@ A GitHub Action that posts Slack messages from CI workflows. Used by Upwave's ba
 | Input     | Required | Default      | Description                          |
 |-----------|----------|--------------|--------------------------------------|
 | `type`    | yes      | —            | `build`, `beforeDeployment`, or `afterDeployment` |
+| `status`  | no       | `success`    | `success` or `failure` — drives the header emoji and colour bar |
 | `token`   | yes      | —            | Slack bot token                      |
 | `channel` | no       | `CFSRFSGP8`  | Channel ID to post to                |
+
+### Status & failure highlighting
+
+Every message renders inside a coloured attachment with a bold header:
+
+- `success` → green bar, `✅ <repo> — published` / `✅ <repo> — deployed (<region> / <env>)`
+- `failure` → red bar, `🚨 <repo> — PUBLISH FAILED` / `🚨 <repo> — DEPLOY FAILED (<region> / <env>)`, plus a `View run ↗` link to the failed Actions run.
+
+The run link is built from the runner's own `GITHUB_SERVER_URL` / `GITHUB_REPOSITORY` / `GITHUB_RUN_ID`, so no workflow wiring is required for it.
 
 ### Environment variables
 
@@ -33,7 +62,7 @@ Per type:
 
 - `build`: `BUILD`, `PUSHED_BY`, `MESSAGE`
 - `beforeDeployment`: `REGION`, `ENVIRONMENT`, `BUILD`, `MESSAGE`
-- `afterDeployment`: `REGION`, `ENVIRONMENT`, `BUILD`, `MESSAGE`
+- `afterDeployment`: `REGION`, `ENVIRONMENT`, `BUILD` (`REGION`/`ENVIRONMENT` appear in the header; the deploy body is just the build version)
 
 Long values (e.g. multi-paragraph commit messages) are truncated to 2800 chars to fit Slack's 3000-char section limit.
 
@@ -60,11 +89,22 @@ When `GITHUB_ACTIONS` is unset, `index.ts` exposes a CLI:
 ```bash
 REPOSITORY=keystone BUILD=1.2.3 PUSHED_BY=dave MESSAGE="local test" \
   yarn local slack build --token xoxb-... --channel C12345678
+
+# Failure variant (renders the 🚨 header, red bar, and run link):
+REPOSITORY=keystone BUILD=1.2.3 PUSHED_BY=dave MESSAGE="local test" \
+  GITHUB_SERVER_URL=https://github.com GITHUB_REPOSITORY=Survata/keystone GITHUB_RUN_ID=123 \
+  yarn local slack build --status failure --token xoxb-... --channel C12345678
 ```
+
+## Versioning: `v1` vs `v2`
+
+`v2` introduced the `status` input and the ✅/🚨 header + colour-bar treatment. It is rolled out **opt-in**: a consumer moves from `@v1` to `@v2` by editing its own workflows (and adding the `if: failure()` steps). There is no big-bang — `v1` is frozen at its last commit and un-migrated repos keep the old plain-text behaviour until their PR lands.
+
+Within a major, the tag is still **floating**: once a repo pins `@v2`, moving the `v2` tag rolls that repo to the newest v2 bundle on its next run. The procedure below applies to patching whichever major is current (substitute `v2` for `v1`).
 
 ## Publishing a new version
 
-All consumers reference `Survata/gha.slack@v1`. The `v1` tag is a **floating tag** — moving it rolls every consumer to the new version on their next workflow run. No consumer-side changes are required.
+The floating major tag rolls every consumer pinned to it to the new bundle on their next workflow run. No consumer-side changes are required for a same-major bundle update.
 
 ### Procedure
 

--- a/README.md
+++ b/README.md
@@ -4,13 +4,14 @@ A GitHub Action that posts Slack messages from CI workflows. Used by Upwave's ba
 
 ## Usage
 
-Success notification (the default — `status` omitted):
+Success notification — pass `status: success` for the ✅ header:
 
 ```yaml
 - name: Send Slack message
   uses: Survata/gha.slack@v2
   with:
     type: build
+    status: success
     token: ${{ secrets.SLACK_BOT_TOKEN }}
   env:
     REPOSITORY: ${{ github.event.repository.name }}
@@ -41,18 +42,19 @@ Failure notification — an `if: failure()` step with `status: failure`:
 | Input     | Required | Default      | Description                          |
 |-----------|----------|--------------|--------------------------------------|
 | `type`    | yes      | —            | `build`, `beforeDeployment`, or `afterDeployment` |
-| `status`  | no       | `success`    | `success` or `failure` — drives the header emoji and colour bar |
+| `status`  | no       | *(none)*     | `success` or `failure` — sets the header emoji and colour bar. Omit for a plain message with no status indicator |
 | `token`   | yes      | —            | Slack bot token                      |
 | `channel` | no       | `CFSRFSGP8`  | Channel ID to post to                |
 
 ### Status & failure highlighting
 
-Every message renders inside a coloured attachment with a bold header:
+`status` is **optional** and has three renderings:
 
-- `success` → green bar, `✅ <repo> — published` / `✅ <repo> — deployed (<region> / <env>)`
-- `failure` → red bar, `🚨 <repo> — PUBLISH FAILED` / `🚨 <repo> — DEPLOY FAILED (<region> / <env>)`, plus a `View run ↗` link to the failed Actions run.
+- `success` → green ("good") bar + bold header `✅ <repo> — published` / `✅ <repo> — deployed (<region> / <env>)`.
+- `failure` → red ("danger") bar + bold header `🚨 <repo> — PUBLISH FAILED` / `🚨 <repo> — DEPLOY FAILED (<region> / <env>)`, plus a `View run ↗` link to the failed Actions run.
+- **omitted** → a plain message (no header, no colour bar) — for notifications where a success/failure status doesn't apply.
 
-The run link is built from the runner's own `GITHUB_SERVER_URL` / `GITHUB_REPOSITORY` / `GITHUB_RUN_ID`, so no workflow wiring is required for it.
+For `success`/`failure`, the run link is built from the runner's own `GITHUB_SERVER_URL` / `GITHUB_REPOSITORY` / `GITHUB_RUN_ID`, so no workflow wiring is required for it. An unrecognised non-empty `status` is treated as `failure` (never a false success), and the action never fails the workflow step over a bad value.
 
 ### Environment variables
 
@@ -87,18 +89,23 @@ The action runs `bin/index.js`, which is a committed bundle produced by `@vercel
 When `GITHUB_ACTIONS` is unset, `index.ts` exposes a CLI:
 
 ```bash
+# Success (✅ header, green bar):
 REPOSITORY=keystone BUILD=1.2.3 PUSHED_BY=dave MESSAGE="local test" \
-  yarn local slack build --token xoxb-... --channel C12345678
+  yarn local slack build --status success --token xoxb-... --channel C12345678
 
-# Failure variant (renders the 🚨 header, red bar, and run link):
+# Failure (🚨 header, red bar, run link):
 REPOSITORY=keystone BUILD=1.2.3 PUSHED_BY=dave MESSAGE="local test" \
   GITHUB_SERVER_URL=https://github.com GITHUB_REPOSITORY=Survata/keystone GITHUB_RUN_ID=123 \
   yarn local slack build --status failure --token xoxb-... --channel C12345678
+
+# No status (plain message — omit --status):
+REPOSITORY=keystone BUILD=1.2.3 PUSHED_BY=dave MESSAGE="local test" \
+  yarn local slack build --token xoxb-... --channel C12345678
 ```
 
 ## Versioning: `v1` vs `v2`
 
-`v2` introduced the `status` input and the ✅/🚨 header + colour-bar treatment. It is rolled out **opt-in**: a consumer moves from `@v1` to `@v2` by editing its own workflows (and adding the `if: failure()` steps). There is no big-bang — `v1` is frozen at its last commit and un-migrated repos keep the old plain-text behaviour until their PR lands.
+`v2` introduced the optional `status` input and the ✅/🚨 header + colour-bar treatment. It is rolled out **opt-in**: a consumer moves from `@v1` to `@v2` by editing its own workflows to pass `status: success` on the existing notify step and add an `if: failure()` step with `status: failure`. There is no big-bang — `v1` is frozen at its last commit and un-migrated repos keep the old plain-text behaviour until their PR lands.
 
 Within a major, the tag is still **floating**: once a repo pins `@v2`, moving the `v2` tag rolls that repo to the newest v2 bundle on its next run. The procedure below applies to patching whichever major is current (substitute `v2` for `v1`).
 

--- a/action.yaml
+++ b/action.yaml
@@ -5,9 +5,8 @@ inputs:
     description: 'Type of Slack message'
     required: true
   status:
-    description: 'success (default) or failure — drives the header emoji and colour bar'
+    description: 'success or failure — sets the header emoji and colour bar. Omit for a plain message with no status indicator.'
     required: false
-    default: success
   token:
     description: 'The Slack access token'
     required: true

--- a/action.yaml
+++ b/action.yaml
@@ -4,6 +4,10 @@ inputs:
   type:
     description: 'Type of Slack message'
     required: true
+  status:
+    description: 'success (default) or failure — drives the header emoji and colour bar'
+    required: false
+    default: success
   token:
     description: 'The Slack access token'
     required: true

--- a/bin/index.js
+++ b/bin/index.js
@@ -91,6 +91,10 @@ function truncate(value, max = exports.MAX_TOKEN_LENGTH) {
     return value.length <= max ? value : value.slice(0, max) + TRUNCATION_SUFFIX;
 }
 exports.truncate = truncate;
+const MAX_HEADER_LENGTH = 150;
+function truncateHeader(header) {
+    return header.length <= MAX_HEADER_LENGTH ? header : header.slice(0, MAX_HEADER_LENGTH - 1) + '…';
+}
 var slackMessageType;
 (function (slackMessageType) {
     slackMessageType["build"] = "build";
@@ -116,11 +120,11 @@ function statusHeader(type, status, repository, region, environment) {
     const location = region && environment ? ` (${region} / ${environment})` : '';
     switch (type) {
         case slackMessageType.build:
-            return `${emoji} ${repository} — ${failed ? 'PUBLISH FAILED' : 'published'}`;
+            return truncateHeader(`${emoji} ${repository} — ${failed ? 'PUBLISH FAILED' : 'published'}`);
         case slackMessageType.beforeDeployment:
-            return `${emoji} ${repository} — ${failed ? 'DEPLOYMENT FAILED' : 'deploying'}${location}`;
+            return truncateHeader(`${emoji} ${repository} — ${failed ? 'DEPLOYMENT FAILED' : 'deploying'}${location}`);
         case slackMessageType.afterDeployment:
-            return `${emoji} ${repository} — ${failed ? 'DEPLOY FAILED' : 'deployed'}${location}`;
+            return truncateHeader(`${emoji} ${repository} — ${failed ? 'DEPLOY FAILED' : 'deployed'}${location}`);
     }
 }
 exports.statusHeader = statusHeader;
@@ -151,7 +155,7 @@ var slack;
         ]))
             .option('--token <string>', 'the Slack authorization bearer token')
             .option('--channel <string>', 'the channel to send the message to')
-            .option('--status <string>', 'success (default) or failure')
+            .option('--status <string>', 'success or failure (omit for no status indicator)')
             .action(async (type, options) => {
             const args = {
                 type: type,
@@ -177,11 +181,20 @@ function buildBody(args) {
         msg = msg.replace(token, value);
     });
     const name = process.env.REPOSITORY || 'undefined';
+    const section = { type: 'section', text: { type: 'mrkdwn', text: msg } };
+    const base = {
+        channel: args.channel,
+        username: `${name}`,
+        icon_url: `https://s3.amazonaws.com/media.upwave.com/slack/${name}.png`,
+    };
+    if (!args.status) {
+        return { ...base, blocks: [{ type: 'divider' }, section] };
+    }
     const header = statusHeader(args.type, args.status, name, process.env.REGION, process.env.ENVIRONMENT);
     const blocks = [
         { type: 'header', text: { type: 'plain_text', text: header, emoji: true } },
         { type: 'divider' },
-        { type: 'section', text: { type: 'mrkdwn', text: msg } },
+        section,
     ];
     if (args.status === slackStatus.failure) {
         const url = runUrl();
@@ -190,10 +203,8 @@ function buildBody(args) {
         }
     }
     return {
-        channel: args.channel,
+        ...base,
         text: header,
-        username: `${name}`,
-        icon_url: `https://s3.amazonaws.com/media.upwave.com/slack/${name}.png`,
         attachments: [{ color: attachmentColor(args.status), blocks }],
     };
 }
@@ -273,7 +284,10 @@ var util;
     }
     util.toType = toType;
     function toStatus(val) {
-        return val === slack_1.slackStatus.failure ? slack_1.slackStatus.failure : slack_1.slackStatus.success;
+        if (!val) {
+            return undefined;
+        }
+        return val === slack_1.slackStatus.success ? slack_1.slackStatus.success : slack_1.slackStatus.failure;
     }
     util.toStatus = toStatus;
 })(util = exports.util || (exports.util = {}));

--- a/bin/index.js
+++ b/bin/index.js
@@ -178,7 +178,7 @@ function buildBody(args) {
     message.tokens.forEach((t) => {
         const token = '%' + t + '%';
         const value = truncate(process.env[t] || 'undefined');
-        msg = msg.replace(token, value);
+        msg = msg.split(token).join(value);
     });
     const name = process.env.REPOSITORY || 'undefined';
     const section = { type: 'section', text: { type: 'mrkdwn', text: msg } };

--- a/bin/index.js
+++ b/bin/index.js
@@ -84,6 +84,7 @@ exports.messageFactory = exports.buildBody = exports.slack = exports.runUrl = ex
 const commander_1 = __nccwpck_require__(909);
 const http_client_1 = __nccwpck_require__(844);
 const core = __importStar(__nccwpck_require__(484));
+const util_1 = __nccwpck_require__(713);
 exports.MAX_TOKEN_LENGTH = 2800;
 const TRUNCATION_SUFFIX = '\n…(truncated)';
 function truncate(value, max = exports.MAX_TOKEN_LENGTH) {
@@ -154,7 +155,7 @@ var slack;
             .action(async (type, options) => {
             const args = {
                 type: type,
-                status: options.status === slackStatus.failure ? slackStatus.failure : slackStatus.success,
+                status: util_1.util.toStatus(options.status),
                 channel: options.channel,
                 token: options.token,
             };
@@ -190,6 +191,7 @@ function buildBody(args) {
     }
     return {
         channel: args.channel,
+        text: header,
         username: `${name}`,
         icon_url: `https://s3.amazonaws.com/media.upwave.com/slack/${name}.png`,
         attachments: [{ color: attachmentColor(args.status), blocks }],

--- a/bin/index.js
+++ b/bin/index.js
@@ -37,6 +37,7 @@ const slack_1 = __nccwpck_require__(373);
 if (util_1.util.isTrue(process.env.GITHUB_ACTIONS)) {
     const args = {
         type: util_1.util.toType(core.getInput('type')),
+        status: util_1.util.toStatus(core.getInput('status')),
         channel: core.getInput('channel'),
         token: core.getInput('token'),
     };
@@ -79,7 +80,7 @@ var __importStar = (this && this.__importStar) || function (mod) {
     return result;
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
-exports.messageFactory = exports.slack = exports.slackMessageType = exports.truncate = exports.MAX_TOKEN_LENGTH = void 0;
+exports.messageFactory = exports.buildBody = exports.slack = exports.runUrl = exports.statusHeader = exports.attachmentColor = exports.slackStatus = exports.slackMessageType = exports.truncate = exports.MAX_TOKEN_LENGTH = void 0;
 const commander_1 = __nccwpck_require__(909);
 const http_client_1 = __nccwpck_require__(844);
 const core = __importStar(__nccwpck_require__(484));
@@ -95,6 +96,43 @@ var slackMessageType;
     slackMessageType["beforeDeployment"] = "beforeDeployment";
     slackMessageType["afterDeployment"] = "afterDeployment";
 })(slackMessageType = exports.slackMessageType || (exports.slackMessageType = {}));
+var slackStatus;
+(function (slackStatus) {
+    slackStatus["success"] = "success";
+    slackStatus["failure"] = "failure";
+})(slackStatus = exports.slackStatus || (exports.slackStatus = {}));
+const HEADER_EMOJI = {
+    [slackStatus.success]: '✅',
+    [slackStatus.failure]: '🚨',
+};
+function attachmentColor(status) {
+    return status === slackStatus.failure ? 'danger' : 'good';
+}
+exports.attachmentColor = attachmentColor;
+function statusHeader(type, status, repository, region, environment) {
+    const emoji = HEADER_EMOJI[status];
+    const failed = status === slackStatus.failure;
+    const location = region && environment ? ` (${region} / ${environment})` : '';
+    switch (type) {
+        case slackMessageType.build:
+            return `${emoji} ${repository} — ${failed ? 'PUBLISH FAILED' : 'published'}`;
+        case slackMessageType.beforeDeployment:
+            return `${emoji} ${repository} — ${failed ? 'DEPLOYMENT FAILED' : 'deploying'}${location}`;
+        case slackMessageType.afterDeployment:
+            return `${emoji} ${repository} — ${failed ? 'DEPLOY FAILED' : 'deployed'}${location}`;
+    }
+}
+exports.statusHeader = statusHeader;
+function runUrl(env = process.env) {
+    const server = env.GITHUB_SERVER_URL;
+    const repository = env.GITHUB_REPOSITORY;
+    const runId = env.GITHUB_RUN_ID;
+    if (!server || !repository || !runId) {
+        return undefined;
+    }
+    return `${server}/${repository}/actions/runs/${runId}`;
+}
+exports.runUrl = runUrl;
 var slack;
 (function (slack) {
     function setupCommand(program) {
@@ -112,9 +150,11 @@ var slack;
         ]))
             .option('--token <string>', 'the Slack authorization bearer token')
             .option('--channel <string>', 'the channel to send the message to')
+            .option('--status <string>', 'success (default) or failure')
             .action(async (type, options) => {
             const args = {
                 type: type,
+                status: options.status === slackStatus.failure ? slackStatus.failure : slackStatus.success,
                 channel: options.channel,
                 token: options.token,
             };
@@ -123,24 +163,39 @@ var slack;
     }
     slack.setupCommand = setupCommand;
     async function run(args) {
-        const message = messageFactory(args.type);
-        let msg = message.content;
-        message.tokens.forEach((t) => {
-            const token = '%' + t + '%';
-            const value = truncate(process.env[t] || 'undefined');
-            msg = msg.replace(token, value);
-        });
-        const name = process.env.REPOSITORY || 'undefined';
-        const body = {
-            channel: args.channel,
-            blocks: [{ type: 'divider' }, { type: 'section', text: { type: 'mrkdwn', text: msg } }],
-            username: `${name}`,
-            icon_url: `https://s3.amazonaws.com/media.upwave.com/slack/${name}.png`,
-        };
-        await post(args.token, body);
+        await post(args.token, buildBody(args));
     }
     slack.run = run;
 })(slack = exports.slack || (exports.slack = {}));
+function buildBody(args) {
+    const message = messageFactory(args.type);
+    let msg = message.content;
+    message.tokens.forEach((t) => {
+        const token = '%' + t + '%';
+        const value = truncate(process.env[t] || 'undefined');
+        msg = msg.replace(token, value);
+    });
+    const name = process.env.REPOSITORY || 'undefined';
+    const header = statusHeader(args.type, args.status, name, process.env.REGION, process.env.ENVIRONMENT);
+    const blocks = [
+        { type: 'header', text: { type: 'plain_text', text: header, emoji: true } },
+        { type: 'divider' },
+        { type: 'section', text: { type: 'mrkdwn', text: msg } },
+    ];
+    if (args.status === slackStatus.failure) {
+        const url = runUrl();
+        if (url) {
+            blocks.push({ type: 'context', elements: [{ type: 'mrkdwn', text: `<${url}|View run ↗>` }] });
+        }
+    }
+    return {
+        channel: args.channel,
+        username: `${name}`,
+        icon_url: `https://s3.amazonaws.com/media.upwave.com/slack/${name}.png`,
+        attachments: [{ color: attachmentColor(args.status), blocks }],
+    };
+}
+exports.buildBody = buildBody;
 function messageFactory(type) {
     switch (type) {
         case slackMessageType.build:
@@ -155,8 +210,8 @@ function messageFactory(type) {
             };
         case slackMessageType.afterDeployment:
             return {
-                content: '_After Deployment:_ %REGION% - %ENVIRONMENT%\n_Build:_ %BUILD%\n_Message:_ %MESSAGE%',
-                tokens: ['REGION', 'ENVIRONMENT', 'BUILD', 'MESSAGE'],
+                content: '_Build:_ %BUILD%',
+                tokens: ['BUILD'],
             };
     }
 }
@@ -215,6 +270,10 @@ var util;
         }
     }
     util.toType = toType;
+    function toStatus(val) {
+        return val === slack_1.slackStatus.failure ? slack_1.slackStatus.failure : slack_1.slackStatus.success;
+    }
+    util.toStatus = toStatus;
 })(util = exports.util || (exports.util = {}));
 
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,6 +11,7 @@ import { slackArgs } from './slackArgs';
 if (util.isTrue(process.env.GITHUB_ACTIONS)) {
     const args: slackArgs = {
         type: util.toType(core.getInput('type')),
+        status: util.toStatus(core.getInput('status')),
         channel: core.getInput('channel'),
         token: core.getInput('token'),
     };

--- a/src/slack.send.test.ts
+++ b/src/slack.send.test.ts
@@ -29,7 +29,12 @@ afterEach(() => {
     delete process.env.ENVIRONMENT;
 });
 
-const args = { type: slackMessageType.build, status: slackStatus.success, channel: 'C12345678', token: 'xoxb-test-token' };
+const args = {
+    type: slackMessageType.build,
+    status: slackStatus.success,
+    channel: 'C12345678',
+    token: 'xoxb-test-token',
+};
 
 describe('slack.run() Slack send via @actions/http-client', () => {
     test('posts to chat.postMessage with bearer auth and the substituted body', async () => {
@@ -136,6 +141,21 @@ describe('buildBody() payload assembly', () => {
         expect(blocks).toHaveLength(4);
         expect(blocks[3].type).toBe('context');
         expect(blocks[3].elements[0].text).toContain('https://github.com/Survata/keystone/actions/runs/7');
+    });
+
+    test('no status → a plain message: no header, colour bar, attachment, or top-level text', () => {
+        const body: any = buildBody({ type: slackMessageType.build, channel: 'C1', token: 't' });
+
+        expect(body.attachments).toBeUndefined();
+        expect(body.text).toBeUndefined();
+        // Plain top-level blocks, matching the pre-status rendering.
+        expect(body.blocks[0].type).toBe('divider');
+        expect(body.blocks[1].type).toBe('section');
+        const serialised = JSON.stringify(body);
+        expect(serialised).not.toContain('✅');
+        expect(serialised).not.toContain('🚨');
+        // The message body is still substituted.
+        expect(serialised).toContain('1.2.3');
     });
 
     test('an afterDeployment body carries only the build, with region/env in the header', () => {

--- a/src/slack.send.test.ts
+++ b/src/slack.send.test.ts
@@ -4,7 +4,7 @@
 
 import { HttpClient } from '@actions/http-client';
 import * as core from '@actions/core';
-import { slack, slackMessageType } from './slack';
+import { slack, slackMessageType, slackStatus } from './slack';
 
 jest.mock('@actions/http-client');
 jest.mock('@actions/core');
@@ -20,7 +20,7 @@ beforeEach(() => {
     process.env.MESSAGE = 'a commit message';
 });
 
-const args = { type: slackMessageType.build, channel: 'C12345678', token: 'xoxb-test-token' };
+const args = { type: slackMessageType.build, status: slackStatus.success, channel: 'C12345678', token: 'xoxb-test-token' };
 
 describe('slack.run() Slack send via @actions/http-client', () => {
     test('posts to chat.postMessage with bearer auth and the substituted body', async () => {
@@ -35,10 +35,32 @@ describe('slack.run() Slack send via @actions/http-client', () => {
         expect(body.channel).toBe('C12345678');
         expect(body.username).toBe('keystone');
         expect(body.icon_url).toContain('/keystone.png');
+        // A successful build renders inside a green ("good") attachment with a ✅ header.
+        expect(body.attachments[0].color).toBe('good');
+        expect(JSON.stringify(body.attachments)).toContain('✅ keystone — published');
         // %BUILD% / %MESSAGE% tokens are substituted from the environment.
-        expect(JSON.stringify(body.blocks)).toContain('1.2.3');
-        expect(JSON.stringify(body.blocks)).toContain('a commit message');
+        expect(JSON.stringify(body.attachments)).toContain('1.2.3');
+        expect(JSON.stringify(body.attachments)).toContain('a commit message');
         expect(core.warning).not.toHaveBeenCalled();
+    });
+
+    test('a failure renders a red attachment, a 🚨 header, and a run link', async () => {
+        postJson.mockResolvedValue({ statusCode: 200, result: { ok: true } });
+        process.env.GITHUB_SERVER_URL = 'https://github.com';
+        process.env.GITHUB_REPOSITORY = 'Survata/keystone';
+        process.env.GITHUB_RUN_ID = '99';
+
+        await slack.run({ ...args, status: slackStatus.failure });
+
+        const [, body] = postJson.mock.calls[0];
+        expect(body.attachments[0].color).toBe('danger');
+        const serialised = JSON.stringify(body.attachments);
+        expect(serialised).toContain('🚨 keystone — PUBLISH FAILED');
+        expect(serialised).toContain('https://github.com/Survata/keystone/actions/runs/99');
+
+        delete process.env.GITHUB_SERVER_URL;
+        delete process.env.GITHUB_REPOSITORY;
+        delete process.env.GITHUB_RUN_ID;
     });
 
     test('warns but does not throw when Slack responds ok:false on HTTP 200', async () => {
@@ -67,7 +89,8 @@ describe('slack.run() Slack send via @actions/http-client', () => {
         await slack.run(args);
 
         const [, body] = postJson.mock.calls[0];
-        const text = body.blocks[1].text.text;
+        // blocks: [0] header, [1] divider, [2] section — the section holds the substituted body.
+        const text = body.attachments[0].blocks[2].text.text;
         expect(text).toContain('…(truncated)');
         expect(text.length).toBeLessThan(3000);
     });

--- a/src/slack.send.test.ts
+++ b/src/slack.send.test.ts
@@ -4,7 +4,7 @@
 
 import { HttpClient } from '@actions/http-client';
 import * as core from '@actions/core';
-import { slack, slackMessageType, slackStatus } from './slack';
+import { buildBody, slack, slackMessageType, slackStatus } from './slack';
 
 jest.mock('@actions/http-client');
 jest.mock('@actions/core');
@@ -18,6 +18,15 @@ beforeEach(() => {
     process.env.BUILD = '1.2.3';
     process.env.PUSHED_BY = 'dave';
     process.env.MESSAGE = 'a commit message';
+});
+
+afterEach(() => {
+    // The GITHUB_* run vars are set by individual tests; clear them so they never leak.
+    delete process.env.GITHUB_SERVER_URL;
+    delete process.env.GITHUB_REPOSITORY;
+    delete process.env.GITHUB_RUN_ID;
+    delete process.env.REGION;
+    delete process.env.ENVIRONMENT;
 });
 
 const args = { type: slackMessageType.build, status: slackStatus.success, channel: 'C12345678', token: 'xoxb-test-token' };
@@ -38,6 +47,8 @@ describe('slack.run() Slack send via @actions/http-client', () => {
         // A successful build renders inside a green ("good") attachment with a ✅ header.
         expect(body.attachments[0].color).toBe('good');
         expect(JSON.stringify(body.attachments)).toContain('✅ keystone — published');
+        // Top-level text drives the mobile push notification / preview.
+        expect(body.text).toBe('✅ keystone — published');
         // %BUILD% / %MESSAGE% tokens are substituted from the environment.
         expect(JSON.stringify(body.attachments)).toContain('1.2.3');
         expect(JSON.stringify(body.attachments)).toContain('a commit message');
@@ -54,13 +65,10 @@ describe('slack.run() Slack send via @actions/http-client', () => {
 
         const [, body] = postJson.mock.calls[0];
         expect(body.attachments[0].color).toBe('danger');
+        expect(body.text).toBe('🚨 keystone — PUBLISH FAILED');
         const serialised = JSON.stringify(body.attachments);
         expect(serialised).toContain('🚨 keystone — PUBLISH FAILED');
         expect(serialised).toContain('https://github.com/Survata/keystone/actions/runs/99');
-
-        delete process.env.GITHUB_SERVER_URL;
-        delete process.env.GITHUB_REPOSITORY;
-        delete process.env.GITHUB_RUN_ID;
     });
 
     test('warns but does not throw when Slack responds ok:false on HTTP 200', async () => {
@@ -93,5 +101,58 @@ describe('slack.run() Slack send via @actions/http-client', () => {
         const text = body.attachments[0].blocks[2].text.text;
         expect(text).toContain('…(truncated)');
         expect(text.length).toBeLessThan(3000);
+    });
+});
+
+describe('buildBody() payload assembly', () => {
+    test('a failure with no GITHUB_* run vars omits the run-link context block', () => {
+        const body: any = buildBody({
+            type: slackMessageType.build,
+            status: slackStatus.failure,
+            channel: 'C1',
+            token: 't',
+        });
+
+        const blocks = body.attachments[0].blocks;
+        // header, divider, section only — no trailing context block when there's no run URL.
+        expect(blocks).toHaveLength(3);
+        expect(blocks.some((b: any) => b.type === 'context')).toBe(false);
+        expect(JSON.stringify(body)).not.toContain('View run');
+    });
+
+    test('a failure with GITHUB_* run vars appends the run-link context block', () => {
+        process.env.GITHUB_SERVER_URL = 'https://github.com';
+        process.env.GITHUB_REPOSITORY = 'Survata/keystone';
+        process.env.GITHUB_RUN_ID = '7';
+
+        const body: any = buildBody({
+            type: slackMessageType.build,
+            status: slackStatus.failure,
+            channel: 'C1',
+            token: 't',
+        });
+
+        const blocks = body.attachments[0].blocks;
+        expect(blocks).toHaveLength(4);
+        expect(blocks[3].type).toBe('context');
+        expect(blocks[3].elements[0].text).toContain('https://github.com/Survata/keystone/actions/runs/7');
+    });
+
+    test('an afterDeployment body carries only the build, with region/env in the header', () => {
+        process.env.REGION = 'us';
+        process.env.ENVIRONMENT = 'staging';
+
+        const body: any = buildBody({
+            type: slackMessageType.afterDeployment,
+            status: slackStatus.failure,
+            channel: 'C1',
+            token: 't',
+        });
+
+        expect(body.text).toBe('🚨 keystone — DEPLOY FAILED (us / staging)');
+        const section = body.attachments[0].blocks[2].text.text;
+        expect(section).toBe('_Build:_ 1.2.3');
+        expect(section).not.toContain('Pushed by');
+        expect(section).not.toContain('Message');
     });
 });

--- a/src/slack.send.test.ts
+++ b/src/slack.send.test.ts
@@ -158,6 +158,22 @@ describe('buildBody() payload assembly', () => {
         expect(serialised).toContain('1.2.3');
     });
 
+    test('substitutes token values literally, not as regex replacement patterns', () => {
+        // A commit message can contain `$&`, `$1`, `$$` etc. — String.replace would
+        // interpret those as replacement patterns and mangle the text.
+        process.env.MESSAGE = 'raise $1 and $& then $$ done';
+
+        const body: any = buildBody({
+            type: slackMessageType.build,
+            status: slackStatus.success,
+            channel: 'C1',
+            token: 't',
+        });
+
+        const section = body.attachments[0].blocks[2].text.text;
+        expect(section).toContain('raise $1 and $& then $$ done');
+    });
+
     test('an afterDeployment body carries only the build, with region/env in the header', () => {
         process.env.REGION = 'us';
         process.env.ENVIRONMENT = 'staging';

--- a/src/slack.test.ts
+++ b/src/slack.test.ts
@@ -62,20 +62,16 @@ describe('test messageFactory()', () => {
 });
 
 describe('statusHeader()', () => {
-    test('build', () => {
-        expect(statusHeader(slackMessageType.build, slackStatus.success, 'keystone')).toBe('✅ keystone — published');
-        expect(statusHeader(slackMessageType.build, slackStatus.failure, 'keystone')).toBe(
-            '🚨 keystone — PUBLISH FAILED',
-        );
-    });
-
-    test('afterDeployment includes region and environment', () => {
-        expect(statusHeader(slackMessageType.afterDeployment, slackStatus.success, 'keystone', 'us', 'staging')).toBe(
-            '✅ keystone — deployed (us / staging)',
-        );
-        expect(statusHeader(slackMessageType.afterDeployment, slackStatus.failure, 'keystone', 'us', 'staging')).toBe(
-            '🚨 keystone — DEPLOY FAILED (us / staging)',
-        );
+    test.each([
+        [slackMessageType.build, slackStatus.success, undefined, undefined, '✅ keystone — published'],
+        [slackMessageType.build, slackStatus.failure, undefined, undefined, '🚨 keystone — PUBLISH FAILED'],
+        [slackMessageType.afterDeployment, slackStatus.success, 'us', 'staging', '✅ keystone — deployed (us / staging)'],
+        [slackMessageType.afterDeployment, slackStatus.failure, 'us', 'staging', '🚨 keystone — DEPLOY FAILED (us / staging)'],
+        // An early deploy failure may not have exported REGION/ENVIRONMENT yet — the header drops the location.
+        [slackMessageType.afterDeployment, slackStatus.failure, undefined, undefined, '🚨 keystone — DEPLOY FAILED'],
+        [slackMessageType.beforeDeployment, slackStatus.failure, 'us', 'staging', '🚨 keystone — DEPLOYMENT FAILED (us / staging)'],
+    ])('%s / %s → %s', (type, status, region, environment, expected) => {
+        expect(statusHeader(type, status, 'keystone', region, environment)).toBe(expected);
     });
 });
 

--- a/src/slack.test.ts
+++ b/src/slack.test.ts
@@ -2,7 +2,16 @@
 
 'use strict';
 
-import { MAX_TOKEN_LENGTH, messageFactory, slackMessageType, truncate } from './slack';
+import {
+    attachmentColor,
+    MAX_TOKEN_LENGTH,
+    messageFactory,
+    runUrl,
+    slackMessageType,
+    slackStatus,
+    statusHeader,
+    truncate,
+} from './slack';
 
 describe('test truncate()', () => {
     test('short values pass through unchanged', () => {
@@ -42,10 +51,54 @@ describe('test messageFactory()', () => {
     });
 
     test('afterDeployment', () => {
+        // Region / environment / status now live in the header, so the body is
+        // just the build version.
         const expected = {
-            content: '_After Deployment:_ %REGION% - %ENVIRONMENT%\n_Build:_ %BUILD%\n_Message:_ %MESSAGE%',
-            tokens: ['REGION', 'ENVIRONMENT', 'BUILD', 'MESSAGE'],
+            content: '_Build:_ %BUILD%',
+            tokens: ['BUILD'],
         };
         expect(messageFactory(slackMessageType.afterDeployment)).toEqual(expected);
+    });
+});
+
+describe('statusHeader()', () => {
+    test('build', () => {
+        expect(statusHeader(slackMessageType.build, slackStatus.success, 'keystone')).toBe('✅ keystone — published');
+        expect(statusHeader(slackMessageType.build, slackStatus.failure, 'keystone')).toBe(
+            '🚨 keystone — PUBLISH FAILED',
+        );
+    });
+
+    test('afterDeployment includes region and environment', () => {
+        expect(statusHeader(slackMessageType.afterDeployment, slackStatus.success, 'keystone', 'us', 'staging')).toBe(
+            '✅ keystone — deployed (us / staging)',
+        );
+        expect(statusHeader(slackMessageType.afterDeployment, slackStatus.failure, 'keystone', 'us', 'staging')).toBe(
+            '🚨 keystone — DEPLOY FAILED (us / staging)',
+        );
+    });
+});
+
+describe('attachmentColor()', () => {
+    test('maps status to Slack attachment colors', () => {
+        expect(attachmentColor(slackStatus.success)).toBe('good');
+        expect(attachmentColor(slackStatus.failure)).toBe('danger');
+    });
+});
+
+describe('runUrl()', () => {
+    test('builds a run URL from the standard GitHub Actions env vars', () => {
+        expect(
+            runUrl({
+                GITHUB_SERVER_URL: 'https://github.com',
+                GITHUB_REPOSITORY: 'Survata/keystone',
+                GITHUB_RUN_ID: '42',
+            }),
+        ).toBe('https://github.com/Survata/keystone/actions/runs/42');
+    });
+
+    test('returns undefined when any component is missing', () => {
+        expect(runUrl({ GITHUB_SERVER_URL: 'https://github.com', GITHUB_REPOSITORY: 'Survata/keystone' })).toBeUndefined();
+        expect(runUrl({})).toBeUndefined();
     });
 });

--- a/src/slack.test.ts
+++ b/src/slack.test.ts
@@ -65,13 +65,43 @@ describe('statusHeader()', () => {
     test.each([
         [slackMessageType.build, slackStatus.success, undefined, undefined, '✅ keystone — published'],
         [slackMessageType.build, slackStatus.failure, undefined, undefined, '🚨 keystone — PUBLISH FAILED'],
-        [slackMessageType.afterDeployment, slackStatus.success, 'us', 'staging', '✅ keystone — deployed (us / staging)'],
-        [slackMessageType.afterDeployment, slackStatus.failure, 'us', 'staging', '🚨 keystone — DEPLOY FAILED (us / staging)'],
+        [
+            slackMessageType.afterDeployment,
+            slackStatus.success,
+            'us',
+            'staging',
+            '✅ keystone — deployed (us / staging)',
+        ],
+        [
+            slackMessageType.afterDeployment,
+            slackStatus.failure,
+            'us',
+            'staging',
+            '🚨 keystone — DEPLOY FAILED (us / staging)',
+        ],
         // An early deploy failure may not have exported REGION/ENVIRONMENT yet — the header drops the location.
         [slackMessageType.afterDeployment, slackStatus.failure, undefined, undefined, '🚨 keystone — DEPLOY FAILED'],
-        [slackMessageType.beforeDeployment, slackStatus.failure, 'us', 'staging', '🚨 keystone — DEPLOYMENT FAILED (us / staging)'],
+        [
+            slackMessageType.beforeDeployment,
+            slackStatus.failure,
+            'us',
+            'staging',
+            '🚨 keystone — DEPLOYMENT FAILED (us / staging)',
+        ],
     ])('%s / %s → %s', (type, status, region, environment, expected) => {
         expect(statusHeader(type, status, 'keystone', region, environment)).toBe(expected);
+    });
+
+    test('caps the header at Slack’s 150-char limit so it never trips invalid_blocks', () => {
+        const header = statusHeader(
+            slackMessageType.afterDeployment,
+            slackStatus.failure,
+            'keystone',
+            'x'.repeat(200),
+            'staging',
+        );
+        expect(header.length).toBeLessThanOrEqual(150);
+        expect(header.endsWith('…')).toBe(true);
     });
 });
 
@@ -94,7 +124,9 @@ describe('runUrl()', () => {
     });
 
     test('returns undefined when any component is missing', () => {
-        expect(runUrl({ GITHUB_SERVER_URL: 'https://github.com', GITHUB_REPOSITORY: 'Survata/keystone' })).toBeUndefined();
+        expect(
+            runUrl({ GITHUB_SERVER_URL: 'https://github.com', GITHUB_REPOSITORY: 'Survata/keystone' }),
+        ).toBeUndefined();
         expect(runUrl({})).toBeUndefined();
     });
 });

--- a/src/slack.ts
+++ b/src/slack.ts
@@ -6,6 +6,7 @@ import { Argument, Command } from 'commander';
 import { HttpClient } from '@actions/http-client';
 import * as core from '@actions/core';
 import { slackArgs } from './slackArgs';
+import { util } from './util';
 
 /**
  * Slack rejects section block text fields longer than 3000 chars, so we truncate
@@ -67,6 +68,7 @@ export function statusHeader(
     switch (type) {
         case slackMessageType.build:
             return `${emoji} ${repository} — ${failed ? 'PUBLISH FAILED' : 'published'}`;
+        // beforeDeployment is a legacy type — no repo currently emits it — kept for completeness.
         case slackMessageType.beforeDeployment:
             return `${emoji} ${repository} — ${failed ? 'DEPLOYMENT FAILED' : 'deploying'}${location}`;
         case slackMessageType.afterDeployment:
@@ -133,8 +135,7 @@ export namespace slack {
             .action(async (type, options) => {
                 const args: slackArgs = {
                     type: type,
-                    // Mirrors util.toStatus: anything that isn't an explicit failure is a success.
-                    status: options.status === slackStatus.failure ? slackStatus.failure : slackStatus.success,
+                    status: util.toStatus(options.status),
                     channel: options.channel,
                     token: options.token,
                 };
@@ -186,6 +187,10 @@ export function buildBody(args: slackArgs): object {
 
     return {
         channel: args.channel,
+        // Top-level text is what Slack shows in mobile push notifications and the
+        // channel-list preview — attachment blocks don't drive those. Mirror the
+        // header so a failure alert reads as a failure before it's even opened.
+        text: header,
         username: `${name}`,
         icon_url: `https://s3.amazonaws.com/media.upwave.com/slack/${name}.png`,
         attachments: [{ color: attachmentColor(args.status), blocks }],

--- a/src/slack.ts
+++ b/src/slack.ts
@@ -28,6 +28,68 @@ export enum slackMessageType { // eslint-disable-line no-unused-vars -- it is us
     afterDeployment = 'afterDeployment', // eslint-disable-line no-unused-vars -- it is used, not sure why this is failing lint
 }
 
+/**
+ * Whether the reported publish/deploy succeeded or failed. Drives the header
+ * emoji and the attachment colour bar.
+ */
+export enum slackStatus { // eslint-disable-line no-unused-vars -- it is used, not sure why this is failing lint
+    success = 'success', // eslint-disable-line no-unused-vars -- it is used, not sure why this is failing lint
+    failure = 'failure', // eslint-disable-line no-unused-vars -- it is used, not sure why this is failing lint
+}
+
+const HEADER_EMOJI: Record<slackStatus, string> = {
+    [slackStatus.success]: '✅',
+    [slackStatus.failure]: '🚨',
+};
+
+/**
+ * The Slack attachment colour for a status — a green ("good") or red ("danger")
+ * bar down the left of the message, so failures are obvious at a glance.
+ */
+export function attachmentColor(status: slackStatus): 'good' | 'danger' {
+    return status === slackStatus.failure ? 'danger' : 'good';
+}
+
+/**
+ * Builds the bold header line, e.g. `🚨 keystone — PUBLISH FAILED` or
+ * `✅ keystone — deployed (us / staging)`.
+ */
+export function statusHeader(
+    type: slackMessageType,
+    status: slackStatus,
+    repository: string,
+    region?: string,
+    environment?: string,
+): string {
+    const emoji: string = HEADER_EMOJI[status];
+    const failed: boolean = status === slackStatus.failure;
+    const location: string = region && environment ? ` (${region} / ${environment})` : '';
+    switch (type) {
+        case slackMessageType.build:
+            return `${emoji} ${repository} — ${failed ? 'PUBLISH FAILED' : 'published'}`;
+        case slackMessageType.beforeDeployment:
+            return `${emoji} ${repository} — ${failed ? 'DEPLOYMENT FAILED' : 'deploying'}${location}`;
+        case slackMessageType.afterDeployment:
+            return `${emoji} ${repository} — ${failed ? 'DEPLOY FAILED' : 'deployed'}${location}`;
+    }
+}
+
+/**
+ * A deep-link to the current Actions run, built from the runner's standard
+ * environment variables (always present under GitHub Actions). Returns
+ * undefined when any component is missing, so callers can omit the link rather
+ * than emit a broken one.
+ */
+export function runUrl(env: Record<string, string | undefined> = process.env): string | undefined {
+    const server: string | undefined = env.GITHUB_SERVER_URL;
+    const repository: string | undefined = env.GITHUB_REPOSITORY;
+    const runId: string | undefined = env.GITHUB_RUN_ID;
+    if (!server || !repository || !runId) {
+        return undefined;
+    }
+    return `${server}/${repository}/actions/runs/${runId}`;
+}
+
 export namespace slack {
     /**
      * Sets up the Command.
@@ -67,9 +129,12 @@ export namespace slack {
             )
             .option('--token <string>', 'the Slack authorization bearer token')
             .option('--channel <string>', 'the channel to send the message to')
+            .option('--status <string>', 'success (default) or failure')
             .action(async (type, options) => {
                 const args: slackArgs = {
                     type: type,
+                    // Mirrors util.toStatus: anything that isn't an explicit failure is a success.
+                    status: options.status === slackStatus.failure ? slackStatus.failure : slackStatus.success,
                     channel: options.channel,
                     token: options.token,
                 };
@@ -83,25 +148,48 @@ export namespace slack {
      * @param args
      */
     export async function run(args: slackArgs): Promise<void> {
-        const message = messageFactory(args.type);
-        let msg = message.content;
-        message.tokens.forEach((t: string) => {
-            const token: string = '%' + t + '%';
-            const value: string = truncate(process.env[t] || 'undefined');
-            msg = msg.replace(token, value);
-        });
-
-        const name: string = process.env.REPOSITORY || 'undefined';
-
-        const body = {
-            channel: args.channel,
-            blocks: [{ type: 'divider' }, { type: 'section', text: { type: 'mrkdwn', text: msg } }],
-            username: `${name}`,
-            icon_url: `https://s3.amazonaws.com/media.upwave.com/slack/${name}.png`,
-        };
-
-        await post(args.token, body);
+        await post(args.token, buildBody(args));
     }
+}
+
+/**
+ * Assembles the Slack `chat.postMessage` payload for a message. Pure w.r.t. the
+ * environment it reads (REPOSITORY / message tokens / REGION / ENVIRONMENT and,
+ * for failures, the GitHub run vars), so it can be unit-tested and rendered
+ * without sending anything.
+ */
+export function buildBody(args: slackArgs): object {
+    const message = messageFactory(args.type);
+    let msg = message.content;
+    message.tokens.forEach((t: string) => {
+        const token: string = '%' + t + '%';
+        const value: string = truncate(process.env[t] || 'undefined');
+        msg = msg.replace(token, value);
+    });
+
+    const name: string = process.env.REPOSITORY || 'undefined';
+    const header: string = statusHeader(args.type, args.status, name, process.env.REGION, process.env.ENVIRONMENT);
+
+    const blocks: any[] = [
+        { type: 'header', text: { type: 'plain_text', text: header, emoji: true } },
+        { type: 'divider' },
+        { type: 'section', text: { type: 'mrkdwn', text: msg } },
+    ];
+
+    // Only failures carry a run link — it's the actionable bit when something breaks.
+    if (args.status === slackStatus.failure) {
+        const url: string | undefined = runUrl();
+        if (url) {
+            blocks.push({ type: 'context', elements: [{ type: 'mrkdwn', text: `<${url}|View run ↗>` }] });
+        }
+    }
+
+    return {
+        channel: args.channel,
+        username: `${name}`,
+        icon_url: `https://s3.amazonaws.com/media.upwave.com/slack/${name}.png`,
+        attachments: [{ color: attachmentColor(args.status), blocks }],
+    };
 }
 
 /**
@@ -130,9 +218,11 @@ export function messageFactory(type: slackMessageType): slackMessage {
                 tokens: ['REGION', 'ENVIRONMENT', 'BUILD', 'MESSAGE'],
             };
         case slackMessageType.afterDeployment:
+            // Region / environment / status are carried by the header, so the
+            // body only needs the build version.
             return {
-                content: '_After Deployment:_ %REGION% - %ENVIRONMENT%\n_Build:_ %BUILD%\n_Message:_ %MESSAGE%',
-                tokens: ['REGION', 'ENVIRONMENT', 'BUILD', 'MESSAGE'],
+                content: '_Build:_ %BUILD%',
+                tokens: ['BUILD'],
             };
     }
 }

--- a/src/slack.ts
+++ b/src/slack.ts
@@ -21,6 +21,17 @@ export function truncate(value: string, max: number = MAX_TOKEN_LENGTH): string 
 }
 
 /**
+ * Slack `header` blocks reject text longer than 150 chars with `invalid_blocks`,
+ * which post() only logs — so an over-long header would silently drop the whole
+ * (often failure) notification. Cap it to stay valid.
+ */
+const MAX_HEADER_LENGTH = 150;
+
+function truncateHeader(header: string): string {
+    return header.length <= MAX_HEADER_LENGTH ? header : header.slice(0, MAX_HEADER_LENGTH - 1) + '…';
+}
+
+/**
  * Defines the types of Slack messages.
  */
 export enum slackMessageType { // eslint-disable-line no-unused-vars -- it is used, not sure why this is failing lint
@@ -67,12 +78,12 @@ export function statusHeader(
     const location: string = region && environment ? ` (${region} / ${environment})` : '';
     switch (type) {
         case slackMessageType.build:
-            return `${emoji} ${repository} — ${failed ? 'PUBLISH FAILED' : 'published'}`;
+            return truncateHeader(`${emoji} ${repository} — ${failed ? 'PUBLISH FAILED' : 'published'}`);
         // beforeDeployment is a legacy type — no repo currently emits it — kept for completeness.
         case slackMessageType.beforeDeployment:
-            return `${emoji} ${repository} — ${failed ? 'DEPLOYMENT FAILED' : 'deploying'}${location}`;
+            return truncateHeader(`${emoji} ${repository} — ${failed ? 'DEPLOYMENT FAILED' : 'deploying'}${location}`);
         case slackMessageType.afterDeployment:
-            return `${emoji} ${repository} — ${failed ? 'DEPLOY FAILED' : 'deployed'}${location}`;
+            return truncateHeader(`${emoji} ${repository} — ${failed ? 'DEPLOY FAILED' : 'deployed'}${location}`);
     }
 }
 
@@ -131,7 +142,7 @@ export namespace slack {
             )
             .option('--token <string>', 'the Slack authorization bearer token')
             .option('--channel <string>', 'the channel to send the message to')
-            .option('--status <string>', 'success (default) or failure')
+            .option('--status <string>', 'success or failure (omit for no status indicator)')
             .action(async (type, options) => {
                 const args: slackArgs = {
                     type: type,
@@ -169,12 +180,24 @@ export function buildBody(args: slackArgs): object {
     });
 
     const name: string = process.env.REPOSITORY || 'undefined';
-    const header: string = statusHeader(args.type, args.status, name, process.env.REGION, process.env.ENVIRONMENT);
+    const section = { type: 'section', text: { type: 'mrkdwn', text: msg } };
+    const base = {
+        channel: args.channel,
+        username: `${name}`,
+        icon_url: `https://s3.amazonaws.com/media.upwave.com/slack/${name}.png`,
+    };
 
+    // No status → a plain message with no header or colour bar. Some notifications
+    // legitimately have no success/failure to report; keep the pre-status rendering.
+    if (!args.status) {
+        return { ...base, blocks: [{ type: 'divider' }, section] };
+    }
+
+    const header: string = statusHeader(args.type, args.status, name, process.env.REGION, process.env.ENVIRONMENT);
     const blocks: any[] = [
         { type: 'header', text: { type: 'plain_text', text: header, emoji: true } },
         { type: 'divider' },
-        { type: 'section', text: { type: 'mrkdwn', text: msg } },
+        section,
     ];
 
     // Only failures carry a run link — it's the actionable bit when something breaks.
@@ -186,13 +209,11 @@ export function buildBody(args: slackArgs): object {
     }
 
     return {
-        channel: args.channel,
+        ...base,
         // Top-level text is what Slack shows in mobile push notifications and the
         // channel-list preview — attachment blocks don't drive those. Mirror the
         // header so a failure alert reads as a failure before it's even opened.
         text: header,
-        username: `${name}`,
-        icon_url: `https://s3.amazonaws.com/media.upwave.com/slack/${name}.png`,
         attachments: [{ color: attachmentColor(args.status), blocks }],
     };
 }

--- a/src/slack.ts
+++ b/src/slack.ts
@@ -176,7 +176,10 @@ export function buildBody(args: slackArgs): object {
     message.tokens.forEach((t: string) => {
         const token: string = '%' + t + '%';
         const value: string = truncate(process.env[t] || 'undefined');
-        msg = msg.replace(token, value);
+        // split/join, not replace(): the value is inserted literally, so a commit
+        // message containing `$&`, `$1`, `$$` etc. isn't interpreted as a
+        // replacement pattern (and every occurrence of the token is substituted).
+        msg = msg.split(token).join(value);
     });
 
     const name: string = process.env.REPOSITORY || 'undefined';

--- a/src/slackArgs.ts
+++ b/src/slackArgs.ts
@@ -9,7 +9,8 @@ import { slackMessageType, slackStatus } from './slack';
  */
 export interface slackArgs {
     type: slackMessageType;
-    status: slackStatus;
+    /** Optional — omit for a plain message with no status header or colour bar. */
+    status?: slackStatus;
     channel: string;
     token: string;
 }

--- a/src/slackArgs.ts
+++ b/src/slackArgs.ts
@@ -2,13 +2,14 @@
 
 'use strict';
 
-import { slackMessageType } from './slack';
+import { slackMessageType, slackStatus } from './slack';
 
 /**
  * Defines a Slack message.
  */
 export interface slackArgs {
     type: slackMessageType;
+    status: slackStatus;
     channel: string;
     token: string;
 }

--- a/src/util.test.ts
+++ b/src/util.test.ts
@@ -3,7 +3,7 @@
 'use strict';
 
 import { util } from './util';
-import { slackMessageType } from './slack';
+import { slackMessageType, slackStatus } from './slack';
 
 describe('test running under github action', () => {
     test('', () => {
@@ -23,5 +23,20 @@ describe('test running under github action', () => {
         expect(util.toType('build')).toBe(slackMessageType.build);
         expect(util.toType('beforeDeployment')).toBe(slackMessageType.beforeDeployment);
         expect(util.toType('afterDeployment')).toBe(slackMessageType.afterDeployment);
+    });
+});
+
+describe('toStatus', () => {
+    test('maps the explicit values', () => {
+        expect(util.toStatus('success')).toBe(slackStatus.success);
+        expect(util.toStatus('failure')).toBe(slackStatus.failure);
+    });
+
+    test('defaults to success for empty, undefined, or unrecognised values', () => {
+        // The `status` input is optional (default success), so anything that
+        // isn't an explicit failure must be treated as a success.
+        expect(util.toStatus('')).toBe(slackStatus.success);
+        expect(util.toStatus(undefined)).toBe(slackStatus.success);
+        expect(util.toStatus('cancelled')).toBe(slackStatus.success);
     });
 });

--- a/src/util.test.ts
+++ b/src/util.test.ts
@@ -32,11 +32,17 @@ describe('toStatus', () => {
         expect(util.toStatus('failure')).toBe(slackStatus.failure);
     });
 
-    test('defaults to success for empty, undefined, or unrecognised values', () => {
-        // The `status` input is optional (default success), so anything that
-        // isn't an explicit failure must be treated as a success.
-        expect(util.toStatus('')).toBe(slackStatus.success);
-        expect(util.toStatus(undefined)).toBe(slackStatus.success);
-        expect(util.toStatus('cancelled')).toBe(slackStatus.success);
+    test('treats empty/undefined as no status (the input is optional)', () => {
+        // Omitting `status` means "no status indicator" — not a claimed success.
+        expect(util.toStatus('')).toBeUndefined();
+        expect(util.toStatus(undefined)).toBeUndefined();
+    });
+
+    test('treats an unrecognised non-empty value as failure, never a false success', () => {
+        // A misconfigured/typo'd status must never post a green ✅ over a real
+        // failure — fail toward alerting. (Not a throw: this action must never
+        // fail the consuming workflow step.)
+        expect(util.toStatus('cancelled')).toBe(slackStatus.failure);
+        expect(util.toStatus('faliure')).toBe(slackStatus.failure);
     });
 });

--- a/src/util.ts
+++ b/src/util.ts
@@ -37,10 +37,17 @@ export namespace util {
     }
 
     /**
-     * Maps the optional `status` input to a slackStatus. The input defaults to
-     * success, so only an explicit "failure" is treated as a failure.
+     * Maps the optional `status` input to a slackStatus, or undefined when it is
+     * omitted (a plain message with no status indicator). "success" is success;
+     * everything else non-empty — "failure" and any unrecognised value — is
+     * failure: a misconfigured status must never post a green success over a real
+     * failure, and we must never throw (this action must never fail the consuming
+     * workflow step).
      */
-    export function toStatus(val: string | undefined): slackStatus {
-        return val === slackStatus.failure ? slackStatus.failure : slackStatus.success;
+    export function toStatus(val: string | undefined): slackStatus | undefined {
+        if (!val) {
+            return undefined;
+        }
+        return val === slackStatus.success ? slackStatus.success : slackStatus.failure;
     }
 }

--- a/src/util.ts
+++ b/src/util.ts
@@ -2,7 +2,7 @@
 
 'use strict';
 
-import { slackMessageType } from './slack';
+import { slackMessageType, slackStatus } from './slack';
 
 export namespace util {
     /**
@@ -34,5 +34,13 @@ export namespace util {
             default:
                 throw new Error(`Unknown message type [${val}]`);
         }
+    }
+
+    /**
+     * Maps the optional `status` input to a slackStatus. The input defaults to
+     * success, so only an explicit "failure" is treated as a failure.
+     */
+    export function toStatus(val: string | undefined): slackStatus {
+        return val === slackStatus.failure ? slackStatus.failure : slackStatus.success;
     }
 }


### PR DESCRIPTION
## What

Adds an optional `status` input to the Slack action so publish/deploy failures are obvious in `#engineering-builds`.

`status` has three renderings:

- `success` → green (`good`) bar + `✅ <repo> — published` / `✅ <repo> — deployed (<region> / <env>)`
- `failure` → red (`danger`) bar + `🚨 <repo> — PUBLISH FAILED` / `🚨 <repo> — DEPLOY FAILED (<region> / <env>)`, plus a `View run ↗` link to the failed run
- **omitted** → a plain message with no header or colour bar (for notifications with no success/failure to report)

There is **no default** — a message only gets a status indicator when one is passed. An unrecognised non-empty value is treated as `failure` (never a false success), and the action never fails the workflow step over a bad value.

Other changes:

- **Run link on failure** is built from the runner's own `GITHUB_SERVER_URL` / `GITHUB_REPOSITORY` / `GITHUB_RUN_ID` — no workflow wiring needed.
- **Top-level `text`** mirrors the header so mobile push notifications / previews read the status.
- **`afterDeployment` body trimmed** — region/env/status live in the header, so the deploy body is just the build version.
- **Header capped at Slack's 150-char limit** so an over-long region/env can't trip `invalid_blocks` and silently drop the alert.
- **Literal token substitution** (`split`/`join`, not `replace`) so a commit message containing `$&` / `$1` / `$$` isn't mangled.
- Extracted a pure `buildBody()` from `run()` so the payload is unit-tested and can be rendered without sending.

## Why

Today a failed **publish** posts nothing to Slack (the notify step is implicitly `if: success()`), and a failed **deploy** posts only the word "Failure" with no highlight. This makes both loud and unmissable.

## Rollout — opt-in via `v2`

Shipped as a new floating **`v2`** tag; `v1` is left frozen. Consumer repos migrate by bumping `@v1` → `@v2`, passing `status: success` on the existing notify step, and adding an `if: failure()` step with `status: failure`. No big-bang.

Pilot repos to follow: keystone, database, llm-orchestrator, pixel-pipeline.

## Testing

- `yarn test` — 31/31 pass (status × type matrix, run-link present/absent, no-status plain body, header 150-cap, literal substitution, best-effort send).
- `yarn lint` + `prettier --check` clean; `yarn package` bundle rebuilt and confirmed to contain the new code.
- Rendered the exact `chat.postMessage` JSON for success, failure, and no-status — valid Block Kit, no new bot scopes required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds status-aware Slack notifications for publish and deployment workflows. The main changes are:

- Optional success and failure headers with matching color bars.
- Direct links to failed GitHub Actions runs.
- Plain messages when status is omitted.
- Header truncation to meet Slack's 150-character limit.
- Literal environment-token substitution and tested payload construction.
- Updated action metadata, documentation, tests, and packaged bundle.
</details>

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

- Unknown status values no longer produce green success alerts.
- Omitted status values render without a success or failure claim.
- Status headers are capped before being added to the Slack payload.
- Source code, tests, and the packaged bundle are consistent.
- No blocking issues were found in the updated code.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/util.ts | Maps omitted status to a plain message and unknown non-empty values to failure. |
| src/slack.ts | Builds status-aware Slack payloads, caps headers, adds failure links, and performs literal token substitution. |
| src/index.ts | Reads the optional action status input and passes its normalized value to Slack. |
| bin/index.js | Updates the committed action bundle to match the source behavior. |

<sub>Reviews (2): Last reviewed commit: ["\[SU-10263\] Substitute token values liter..."](https://github.com/survata/gha.slack/commit/237a74b133353d1e97d70e4362544a46f7a1821a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46169624)</sub>

**Context used:**

- Context used - Only call out important issues. Our team has limit... ([source](https://app.greptile.com/review/custom-context?memory=instruction-0))

<!-- /greptile_comment -->