### PR TITLE
[SU-10263] Fix duplicated header in v2 Slack messages

### DIFF
--- a/bin/index.js
+++ b/bin/index.js
@@ -204,8 +204,7 @@ function buildBody(args) {
     }
     return {
         ...base,
-        text: header,
-        attachments: [{ color: attachmentColor(args.status), blocks }],
+        attachments: [{ color: attachmentColor(args.status), fallback: header, blocks }],
     };
 }
 exports.buildBody = buildBody;

--- a/src/slack.send.test.ts
+++ b/src/slack.send.test.ts
@@ -52,8 +52,10 @@ describe('slack.run() Slack send via @actions/http-client', () => {
         // A successful build renders inside a green ("good") attachment with a ✅ header.
         expect(body.attachments[0].color).toBe('good');
         expect(JSON.stringify(body.attachments)).toContain('✅ keystone — published');
-        // Top-level text drives the mobile push notification / preview.
-        expect(body.text).toBe('✅ keystone — published');
+        // No top-level text — it would render a second time above the attachment and
+        // duplicate the header. The notification summary lives in the attachment fallback.
+        expect(body.text).toBeUndefined();
+        expect(body.attachments[0].fallback).toBe('✅ keystone — published');
         // %BUILD% / %MESSAGE% tokens are substituted from the environment.
         expect(JSON.stringify(body.attachments)).toContain('1.2.3');
         expect(JSON.stringify(body.attachments)).toContain('a commit message');
@@ -70,7 +72,8 @@ describe('slack.run() Slack send via @actions/http-client', () => {
 
         const [, body] = postJson.mock.calls[0];
         expect(body.attachments[0].color).toBe('danger');
-        expect(body.text).toBe('🚨 keystone — PUBLISH FAILED');
+        expect(body.text).toBeUndefined();
+        expect(body.attachments[0].fallback).toBe('🚨 keystone — PUBLISH FAILED');
         const serialised = JSON.stringify(body.attachments);
         expect(serialised).toContain('🚨 keystone — PUBLISH FAILED');
         expect(serialised).toContain('https://github.com/Survata/keystone/actions/runs/99');
@@ -185,7 +188,7 @@ describe('buildBody() payload assembly', () => {
             token: 't',
         });
 
-        expect(body.text).toBe('🚨 keystone — DEPLOY FAILED (us / staging)');
+        expect(body.attachments[0].blocks[0].text.text).toBe('🚨 keystone — DEPLOY FAILED (us / staging)');
         const section = body.attachments[0].blocks[2].text.text;
         expect(section).toBe('_Build:_ 1.2.3');
         expect(section).not.toContain('Pushed by');

--- a/src/slack.ts
+++ b/src/slack.ts
@@ -213,11 +213,10 @@ export function buildBody(args: slackArgs): object {
 
     return {
         ...base,
-        // Top-level text is what Slack shows in mobile push notifications and the
-        // channel-list preview — attachment blocks don't drive those. Mirror the
-        // header so a failure alert reads as a failure before it's even opened.
-        text: header,
-        attachments: [{ color: attachmentColor(args.status), blocks }],
+        // `fallback` — not top-level `text` — carries the notification/preview
+        // summary. A top-level `text` renders a second time above the attachment
+        // and duplicates the header line; `fallback` isn't shown in the message body.
+        attachments: [{ color: attachmentColor(args.status), fallback: header, blocks }],
     };
 }
 


### PR DESCRIPTION
## Problem

The v2 Slack messages render the header line **twice** in-channel (confirmed in `#engineering-builds` during the llm-orchestrator trial).

Root cause: all blocks live inside the **attachment** (needed for the colour bar), so there are no top-level `blocks`. Slack's rule is that top-level `text` is a notification fallback *only when using top-level blocks* — otherwise it's rendered as the **main body text**. So the top-level `text` I'd added for push notifications rendered as a line above the attachment, duplicating the header block.

## Fix

Drop top-level `text`; put the notification/preview summary in the attachment's `fallback` field, which drives notifications but is **not** rendered in the message body. Header now appears exactly once, still with the colour bar + bold header block.

## Testing

- 31/31 tests pass (assert `body.text` undefined + `attachments[0].fallback` set for success & failure; header block still present).
- lint + prettier clean; bundle rebuilt.
- Independent review confirmed the mechanism against Slack docs.
- Re-running the llm-orchestrator trial against this commit to visually confirm the single header before moving the `v2` tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)