### PR TITLE
[SU-10359] Patch js-yaml CVE-2026-59869; retarget release docs from v1 to v2

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,8 +3,14 @@
 # IMPORTANT: merging a Dependabot PR is NOT a deploy. The shipped artifact is the
 # committed `bin/index.js` ncc bundle, which Dependabot does NOT regenerate. After
 # merging any dependency bump you must run `yarn package`, commit the regenerated
-# `bin/index.js`, and move the `v1` tag — otherwise every consumer keeps running the
+# `bin/index.js`, and move the `v2` tag — otherwise every consumer keeps running the
 # old code. See "Dependency updates (Dependabot)" in README.md.
+#
+# Exception: most dev-only advisories (eslint/jest and their transitives) never enter
+# the bundle. `typescript` and `@vercel/ncc` are the exception to that exception — they
+# BUILD the bundle, so bumping either does rewrite it. The test is empirical, not by
+# category: if `yarn package` reproduces `bin/index.js` byte-for-byte, the lockfile bump
+# is the whole fix and `v2` must NOT move.
 #
 # Updates are grouped (production / development × version / security) so we get a
 # handful of consolidated PRs instead of one PR per advisory.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ Guidance for Claude Code sessions working in this repository.
 
 ## What this is
 
-A custom GitHub Action that posts Slack messages on publish / before-deployment / after-deployment events. Written in TypeScript, bundled to a single JS file with `@vercel/ncc`, and consumed by every Upwave backend repo via `uses: Survata/gha.slack@v1`.
+A custom GitHub Action that posts Slack messages on publish / before-deployment / after-deployment events. Written in TypeScript, bundled to a single JS file with `@vercel/ncc`, and consumed by every Upwave backend repo via `uses: Survata/gha.slack@v2`.
 
 Not published to the GitHub Marketplace. It works because any public repo with an `action.yaml` at the root is usable as an action by reference (`owner/repo@ref`).
 
@@ -35,14 +35,17 @@ yarn package    # tsc + ncc → bin/index.js
 
 ## Publishing
 
-See [README.md](README.md) for the publish procedure. Key thing to remember: all consumers pin `@v1`, so moving the `v1` tag rolls everyone in one shot. There is no per-consumer change required.
+See [README.md](README.md) for the publish procedure. Key thing to remember: all consumers pin `@v2`, so moving the `v2` tag rolls everyone in one shot. There is no per-consumer change required.
+
+`v1` is retired. Every consumer has been migrated to `@v2` and no references to `@v1` remain; the tag is left in place, frozen, only as a safety net for anything unknown still pointing at it. **Never move `v1`** — it is not a rollout channel any more.
 
 ## Dependency updates (Dependabot)
 
 - Config lives in [`.github/dependabot.yml`](.github/dependabot.yml). Updates are **grouped** (production / development × version / security) to avoid one PR per advisory. Only the `npm` ecosystem is monitored — there are no GitHub Actions workflows in this repo.
 - **Merging a Dependabot PR does NOT ship the fix.** It only updates `package.json` / `yarn.lock`; the running artifact is the committed `bin/index.js` bundle, which Dependabot does not regenerate. A bare merge leaves consumers on the old code.
-- To actually deploy a dependency bump: check out the change, then `yarn install && yarn lint && yarn test && yarn package`, commit the regenerated `bin/index.js` alongside the lockfile, and **move the `v1` tag** (full steps in README's "Dependency updates (Dependabot)" section). Nothing is live until `v1` moves.
+- To actually deploy a dependency bump: check out the change, then `yarn install && yarn lint && yarn test && yarn package`, commit the regenerated `bin/index.js` alongside the lockfile, and **move the `v2` tag** (full steps in README's "Dependency updates (Dependabot)" section). Nothing is live until `v2` moves.
+- **Most dev-only advisories ship nothing.** The bulk of what Dependabot raises here is transitive under eslint/jest and never enters the bundle — but `typescript` and `@vercel/ncc` are devDependencies that *build* the bundle, so those do change it. Decide empirically rather than by category: if `yarn package` reproduces the committed `bin/index.js` byte-for-byte, the lockfile bump is the whole fix and `v2` must not move.
 
 ## Consumers
 
-Currently used by 9 repos: keystone, survata-dashboard, survata-jobs, survata-surveywall-api, campaign-creator, email-service, llm-orchestrator, survata-com, upwave-app. All pin `@v1`. Any breaking change must keep `@v1` working or coordinate updates across all of them.
+Currently used by 9 repos: keystone, survata-dashboard, survata-jobs, survata-surveywall-api, campaign-creator, email-service, llm-orchestrator, survata-com, upwave-app. All pin `@v2`. Any breaking change must keep `@v2` working or coordinate updates across all of them.

--- a/README.md
+++ b/README.md
@@ -103,11 +103,11 @@ REPOSITORY=keystone BUILD=1.2.3 PUSHED_BY=dave MESSAGE="local test" \
   yarn local slack build --token xoxb-... --channel C12345678
 ```
 
-## Versioning: `v1` vs `v2`
+## Versioning: `v2` is the live tag
 
-`v2` introduced the optional `status` input and the ✅/🚨 header + colour-bar treatment. It is rolled out **opt-in**: a consumer moves from `@v1` to `@v2` by editing its own workflows to pass `status: success` on the existing notify step and add an `if: failure()` step with `status: failure`. There is no big-bang — `v1` is frozen at its last commit and un-migrated repos keep the old plain-text behaviour until their PR lands.
+`v2` introduced the optional `status` input and the ✅/🚨 header + colour-bar treatment. **The migration is complete — every consumer now pins `@v2`, and `v1` has no references left.** The `v1` tag is left in place, frozen at its last commit, purely so any stale reference outside the known consumer list keeps resolving. Don't move it, and don't add features to it.
 
-Within a major, the tag is still **floating**: once a repo pins `@v2`, moving the `v2` tag rolls that repo to the newest v2 bundle on its next run. The procedure below applies to patching whichever major is current (substitute `v2` for `v1`).
+`v2` is a **floating** tag: moving it rolls every consumer to the newest bundle on their next workflow run. All the procedures below operate on `v2`.
 
 ## Publishing a new version
 
@@ -137,17 +137,17 @@ The floating major tag rolls every consumer pinned to it to the new bundle on th
 4. **Optional but recommended for non-trivial changes — staged rollout via release-candidate tag.** Push a temporary tag, point one low-stakes consumer at it, watch one publish cycle, then promote:
 
    ```bash
-   git tag v1-rc <sha>
-   git push origin v1-rc
+   git tag v2-rc <sha>
+   git push origin v2-rc
    ```
 
-   In a chosen consumer repo (e.g. `email-service`), temporarily change `uses: Survata/gha.slack@v1` to `uses: Survata/gha.slack@v1-rc`, run a publish, and confirm the Slack message arrives correctly. Then revert that change and proceed to step 5.
+   In a chosen consumer repo (e.g. `email-service`), temporarily change `uses: Survata/gha.slack@v2` to `uses: Survata/gha.slack@v2-rc`, run a publish, and confirm the Slack message arrives correctly. Then revert that change and proceed to step 5.
 
-5. **Move the `v1` tag** to the new commit. This is the moment of rollout:
+5. **Move the `v2` tag** to the new commit. This is the moment of rollout:
 
    ```bash
-   git tag -f v1 <sha>
-   git push origin v1 --force
+   git tag -f v2 <sha>
+   git push origin v2 --force
    ```
 
    All 9 consumer repos pick up the new version on their next workflow run.
@@ -155,22 +155,22 @@ The floating major tag rolls every consumer pinned to it to the new bundle on th
 6. **Optional — cut an immutable version tag** for traceability:
 
    ```bash
-   git tag v1.1.0 <sha>
-   git push origin v1.1.0
+   git tag v2.1.0 <sha>
+   git push origin v2.1.0
    ```
 
 7. Clean up the RC tag if you created one:
 
    ```bash
-   git push origin :v1-rc
-   git tag -d v1-rc
+   git push origin :v2-rc
+   git tag -d v2-rc
    ```
 
 ### Manual steps that aren't scripted
 
 - Reviewing the regenerated `bin/index.js` diff is generally not useful — it's a 470kB webpack bundle. Trust the source diff and the tests.
 - There is no Marketplace release flow. The action is not listed there; consumers reference the repo directly.
-- There is no semantic-versioning automation. You decide when to cut `v1.x.y` and whether to move `v1`.
+- There is no semantic-versioning automation. You decide when to cut `v2.x.y` and whether to move `v2`.
 - Repository icon: each consumer expects an icon at `https://s3.amazonaws.com/media.upwave.com/slack/<repo-name>.png`. When onboarding a new consumer, upload its icon to that S3 path.
 
 ## Dependency updates (Dependabot)
@@ -181,7 +181,7 @@ Dependabot is configured in [`.github/dependabot.yml`](.github/dependabot.yml). 
 
 The artifact that actually runs in consumer workflows is the committed `bin/index.js` bundle, **not** `package.json` / `yarn.lock`. A Dependabot PR only updates the manifests and the lockfile — it does **not** regenerate the bundle. If you merge a Dependabot PR and stop there, every consumer keeps running the old, unpatched code that is still baked into `bin/index.js`.
 
-To actually ship a dependency update you must rebuild the bundle and move the `v1` tag:
+To actually ship a dependency update you must rebuild the bundle and move the `v2` tag — **unless the bump never reaches the bundle**, which for this repo is the common case. Step 3 is where you find out which situation you're in; don't skip ahead to the tag move.
 
 1. Merge (or check out) the Dependabot branch so `package.json` / `yarn.lock` are updated.
 
@@ -194,13 +194,23 @@ To actually ship a dependency update you must rebuild the bundle and move the `v
    yarn package
    ```
 
-3. Commit the regenerated bundle together with the lockfile change:
+3. **Decide whether this bump ships anything at all**, by checking whether the rebuild changed the bundle:
+
+   ```bash
+   git status --porcelain bin/index.js
+   ```
+
+   **No output — the bundle is byte-identical.** The advisory was for a dev-only *runtime* dependency (eslint, Jest, or one of their transitive deps) that never enters the shipped artifact. There is nothing to roll out: commit `package.json` and `yarn.lock` alone, leave `bin/index.js` untouched, and **do not move `v2`**. You are done — stop here.
+
+   **The bundle changed.** The dependency is baked into the shipped artifact, so continue to step 4. Note this also covers `typescript` and `@vercel/ncc`: they are devDependencies, but they *build* the bundle, so bumping either rewrites it and it does need to ship.
+
+4. Commit the regenerated bundle together with the lockfile change:
 
    ```bash
    git add package.json yarn.lock bin/index.js
    git commit -m "Rebuild bundle after dependency update"
    ```
 
-4. Follow [Publishing a new version](#publishing-a-new-version) from step 4 — optionally validate via the `v1-rc` tag, then **move the `v1` tag** to the new commit. The rollout is not live until `v1` moves.
+5. Follow [Publishing a new version](#publishing-a-new-version) from step 4 — optionally validate via the `v2-rc` tag, then **move the `v2` tag** to the new commit. The rollout is not live until `v2` moves.
 
-A quick way to confirm a bump actually reached the bundle: after `yarn package`, grep `bin/index.js` for the new version string or the patched code before moving `v1`.
+To confirm a bump actually reached the bundle beyond the byte-comparison in step 3, grep `bin/index.js` for the new version string or the patched code before moving `v2`.

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "minimatch": "^3.1.5",
     "flatted": "^3.4.2",
     "picomatch": "^2.3.2",
-    "js-yaml": "^4.2.0",
+    "js-yaml": "^4.3.0",
     "@babel/core": "^7.29.6",
     "@babel/traverse": "^7.29.6"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -2132,10 +2132,10 @@ js-tokens@^4.0.0:
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-4.0.0.tgz#19203fb59991df98e3a287050d4647cdeaf32499"
   integrity sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==
 
-js-yaml@^3.13.1, js-yaml@^4.1.0, js-yaml@^4.2.0:
-  version "4.2.0"
-  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-4.2.0.tgz#2bd9e85682dd91bd469afb809d816043b3d49524"
-  integrity sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==
+js-yaml@^3.13.1, js-yaml@^4.1.0, js-yaml@^4.3.0:
+  version "4.3.0"
+  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-4.3.0.tgz#d1900572a7f7cf0b5f540c83673e60bad3436592"
+  integrity sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==
   dependencies:
     argparse "^2.0.1"
 


### PR DESCRIPTION
Closes [SU-10359](https://survata.atlassian.net/browse/SU-10359). Fixes Dependabot alert [#71](https://github.com/Survata/gha.slack/security/dependabot/71).

## The CVE

**[GHSA-52cp-r559-cp3m](https://github.com/advisories/GHSA-52cp-r559-cp3m) / CVE-2026-59869** — `js-yaml`, High, CVSS 3.1 **7.5** (`AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H` — availability only, no confidentiality or integrity impact).

A chain of YAML merge keys (`<<: *anchor`) makes the loader re-enumerate inherited keys, giving O(N²) CPU for O(N) input. Upstream PoC: N=4000 in a sub-100 KB document takes >1s.

Repo was on **4.2.0**, inside the vulnerable range `>=4.0.0 <4.3.0`. Fixed in **4.3.0**.

## Were we actually vulnerable? Effectively no — but it's worth patching

**1. It is not in the shipped artifact.** `js-yaml` is a dev-only transitive dep (via `eslint`, `@eslint/eslintrc`, `@istanbuljs/load-nyc-config`). Zero hits for `js-yaml`, `YAMLException`, `tag:yaml.org` or `argparse` in `bin/index.js`. No consumer on `@v2` has ever loaded it.

**2. It genuinely does execute in our dev/CI toolchain.** `.eslintrc` is extensionless, so eslint routes it through `loadLegacyConfigFile()` → `js-yaml.load()` on every `yarn lint`. Real code path — but the input is a 20-line JSON file we control, with no merge keys. (`@istanbuljs/load-nyc-config` isn't reached at all: no `.nycrc*` exists and `yarn test` runs no coverage.)

**3. No untrusted input can reach it.** `checkCommit.yaml` triggers on `push` with `branches-ignore: master`. Fork PRs raise `pull_request`, not `push`, so a fork cannot trigger the workflow at all — only someone with write access can get eslint to parse a file they authored. Worst case is a CI runner burning CPU to job timeout. Nothing leaks.

So: not exploitable, but the fix is free and it clears the alert.

## The fix

One line in `resolutions`, `js-yaml: ^4.2.0` → `^4.3.0`, plus the lockfile.

The bump is mechanically necessary — `^4.2.0` was already satisfied by the locked 4.2.0, so a bare `yarn install` would have moved nothing.

**The pin is load-bearing, not cosmetic.** `@istanbuljs/load-nyc-config` requests `js-yaml@^3.13.1`, which falls in the advisory's *other* vulnerable range (`>=3.0.0 <3.15.0`). Forcing 4.3.0 closes both branches with one pin. That package calls only `load()`, which exists in v3 and v4 alike, so the major forcing is safe — and `yarn lint` passing is an end-to-end confirmation of it.

Upstream 4.2.0→4.3.0 is surgical: `lib/loader.js` (+7/−11) plus es5 build fixes. It swaps `maxMergeSeqLength` for `maxTotalMergeKeys` (default 10000). Nothing in our tree passes loader options. Staying on 4.x deliberately — 4.3.0 is npm dist-tag `v4-legacy`, `latest` is 5.2.2, and eslint 8 expects 4.x.

## ⚠️ This ships nothing — do not move `v2`

`yarn package` reproduces `bin/index.js` **byte-for-byte** (md5 `896199c33a01f4204d18132c8081609e`, unchanged). The bundle is deliberately not touched in this PR, and the `v2` tag must not move for it.

## Docs: v1 → v2

The v1→v2 migration is complete — all 9 consumers pin `@v2` and no `@v1` references remain — but the release procedures still told you to move `v1`. Retargeted across `README.md`, `CLAUDE.md` and `.github/dependabot.yml`. `v1` is now documented as retired and frozen: left in place as a safety net for any unknown stale reference, never to be moved again. No generic "current major" abstraction was introduced; this is a straight substitution.

The Dependabot procedure also gains an explicit **"does this bump ship anything?"** step *before* the tag move — most advisories here are dev-only and ship nothing, and the old ordering would have had you move the tag before reaching that caveat. `typescript` and `@vercel/ncc` are called out as the devDependencies that *do* rewrite the bundle, so the rule is stated as an empirical rebuild-and-diff test rather than a category.

## Verification

- `yarn lint` — clean
- `yarn test` — **31 passed**, 3 suites
- `yarn package` — `bin/index.js` byte-identical to the committed artifact
- `js-yaml` resolves to 4.3.0; single copy in the tree, no nested duplicates
- Lockfile diff is exactly the 8 js-yaml lines, no incidental re-resolution churn
- `.github/dependabot.yml` still parses as YAML
- No `@v1` references left in any tracked file
- Reviewed by a separate agent; its one medium finding (the step-ordering defect above) is fixed in this PR

## Follow-ups, deliberately not in this PR

- Add `git diff --exit-code bin/index.js` to `checkCommit.yaml` to enforce the rebuild-and-diff rule in CI. Needs `yarn package` confirmed reproducible on CI's Node 20 first.
- `README.md:171` describes the bundle as "470kB"; it is ~239 kB. Pre-existing and out of scope here.
- Four stale open Dependabot PRs (#4, #11, #14, #16) predate the grouped config and look superseded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015nd9GuuZiTphT1iq8r3sGd

[SU-10359]: https://survata.atlassian.net/browse/SU-10359?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ