### PR TITLE
[SU-10639] Bump js-yaml to 4.3.1 (GHSA-5p4m-2wfm-xmqj)

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "minimatch": "^3.1.5",
     "flatted": "^3.4.2",
     "picomatch": "^2.3.2",
-    "js-yaml": "^4.3.0",
+    "js-yaml": "^4.3.1",
     "@babel/core": "^7.29.6",
     "@babel/traverse": "^7.29.6"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -2132,10 +2132,10 @@ js-tokens@^4.0.0:
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-4.0.0.tgz#19203fb59991df98e3a287050d4647cdeaf32499"
   integrity sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==
 
-js-yaml@^3.13.1, js-yaml@^4.1.0, js-yaml@^4.3.0:
-  version "4.3.0"
-  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-4.3.0.tgz#d1900572a7f7cf0b5f540c83673e60bad3436592"
-  integrity sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==
+js-yaml@^3.13.1, js-yaml@^4.1.0, js-yaml@^4.3.1:
+  version "4.3.1"
+  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-4.3.1.tgz#01216c001d67f48e2cd560d708c7af21090a3848"
+  integrity sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==
   dependencies:
     argparse "^2.0.1"
 


### PR DESCRIPTION
Clears the one open Dependabot alert on this repo (#74, js-yaml GHSA-5p4m-2wfm-xmqj, High/7.5 — O(n²) `!!omap` DoS in `yaml.load()`).

## What this is

`gha.slack` is our custom GitHub Action for posting to Slack. The running artifact is the committed ncc bundle `bin/index.js`; the TypeScript sources and dev toolchain are not shipped.

## Why the alert is not a production risk

- **js-yaml is dev-only and transitive** — pulled by `eslint` and `jest → @istanbuljs/load-nyc-config`. It is not in `dependencies`.
- **It is absent from the shipped bundle.** `bin/index.js` contains zero js-yaml/`omap` references, and the action parses no YAML. The DoS vector (`yaml.load()` on untrusted input) does not exist at runtime; dev tooling only ever parses developer-authored config.

So this bump is purely to clear the alert — it changes nothing at runtime.

## The change

- Raise the existing `resolutions` floor `js-yaml` `^4.3.0` → `^4.3.1` (`package.json`), and update `yarn.lock`. All requesters collapse onto a single **js-yaml 4.3.1** (stays on the 4.x/CJS line; 5.x is an ESM-only rewrite that would break these consumers). 4.3.1 was published 2026-07-31.
- **`bin/index.js` is deliberately not touched.** `yarn package` reproduces the committed bundle byte-for-byte (sha256 unchanged), confirming js-yaml never enters it.

## Deploy note

**The `v2` tag must NOT move for this PR.** Nothing in the runtime bundle changed, so there is nothing to publish — merging the lockfile bump is the whole fix. (Moving `v2` is only required when `bin/index.js` itself changes.)

Reviewed by a separate agent; `yarn lint` and `yarn test` (31 tests) green under Node 24.